### PR TITLE
Added liked_by brand action

### DIFF
--- a/core/apps/brand/schema.py
+++ b/core/apps/brand/schema.py
@@ -4,7 +4,7 @@ from drf_spectacular.utils import extend_schema
 from core.apps.brand.serializers import (
     MatchSerializer,
     InstantCoopRequestSerializer,
-    InstantCoopSerializer, CollaborationSerializer
+    InstantCoopSerializer, CollaborationSerializer, LikedBySerializer
 )
 
 
@@ -93,6 +93,16 @@ class Fix1(OpenApiViewExtension):
             )
             def instant_coop(self, request, *args, **kwargs):
                 return super().instant_coop(request, *args, **kwargs)
+
+            @extend_schema(
+                tags=['Brand'],
+                description="Get a list of brands that liked the current one.\n\n"
+                            "Excludes matches and likes of current brand.\n\n"
+                            "Authenticated brand only.",
+                responses={200: LikedBySerializer(many=True)}
+            )
+            def liked_by(self, request, *args, **kwargs):
+                return super().liked_by(request, *args, **kwargs)
 
         return Fixed
 

--- a/core/apps/brand/serializers.py
+++ b/core/apps/brand/serializers.py
@@ -964,3 +964,9 @@ class CollaborationSerializer(serializers.ModelSerializer):
             raise exceptions.ValidationError("Failed to perform action!")
 
         return collab
+
+
+class LikedBySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Brand
+        fields = ['id', 'name', 'logo']

--- a/tests/brand/test_liked_by.py
+++ b/tests/brand/test_liked_by.py
@@ -1,0 +1,118 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from core.apps.brand.models import Category, Brand
+
+User = get_user_model()
+
+
+class LikedByTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user1 = User.objects.create_user(
+            email='user1@example.com',
+            phone='+79993332211',
+            fullname='Юзеров Юзер Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.user2 = User.objects.create_user(
+            email='user2@example.com',
+            phone='+79993332212',
+            fullname='Юзеров Юзер1 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.user3 = User.objects.create_user(
+            email='user3@example.com',
+            phone='+79993332213',
+            fullname='Юзеров Юзер2 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.auth_client1 = APIClient()
+        cls.auth_client2 = APIClient()
+        cls.auth_client3 = APIClient()
+
+        cls.auth_client1.force_authenticate(cls.user1)
+        cls.auth_client2.force_authenticate(cls.user2)
+        cls.auth_client3.force_authenticate(cls.user3)
+
+        brand_data = {
+            'tg_nickname': '@asfhbnaf',
+            'name': 'brand1',
+            'position': 'position',
+            'category': Category.objects.get(pk=1),
+            'inst_url': 'https://example.com',
+            'vk_url': 'https://example.com',
+            'tg_url': 'https://example.com',
+            'wb_url': 'https://example.com',
+            'lamoda_url': 'https://example.com',
+            'site_url': 'https://example.com',
+            'subs_count': 10000,
+            'avg_bill': 10000,
+            'uniqueness': 'uniqueness',
+            'logo': 'string',
+            'photo': 'string'
+        }
+
+        cls.brand1 = Brand.objects.create(user=cls.user1, **brand_data)
+        cls.brand2 = Brand.objects.create(user=cls.user2, **brand_data)
+        cls.brand3 = Brand.objects.create(user=cls.user3, **brand_data)
+
+        cls.like_url = reverse('brand-like')
+        cls.url = reverse('brand-liked_by')
+
+    def test_unauthenticated_not_allowed(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_without_brand_not_allowed(self):
+        user_wo_brand = User.objects.create_user(
+            email='user4@example.com',
+            phone='+79993332214',
+            fullname='Юзеров Юзер3 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+        auth_client = APIClient()
+        auth_client.force_authenticate(user_wo_brand)
+
+        response = auth_client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_liked_by_returns_empty_list_if_no_likes(self):
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data)
+
+    def test_liked_by_returns_correct_list_of_brands(self):
+        self.auth_client2.post(self.like_url, {'target': self.brand1.id})  # brand2 likes brand1
+        self.auth_client2.post(self.like_url, {'target': self.brand3.id})  # brand2 likes brand3
+        self.auth_client1.post(self.like_url, {'target': self.brand3.id})  # brand1 likes brand3
+
+        response = self.auth_client1.get(self.url)  # get who liked brand1
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], self.brand2.id)
+
+    def test_liked_by_excludes_matches(self):
+        self.auth_client2.post(self.like_url, {'target': self.brand1.id})  # brand2 likes brand1
+        self.auth_client3.post(self.like_url, {'target': self.brand1.id})  # brand3 likes brand1
+        self.auth_client1.post(self.like_url, {'target': self.brand3.id})  # brand1 likes brand3 MATCH!
+
+        response = self.auth_client1.get(self.url)  # get who liked brand1
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 1)


### PR DESCRIPTION
Liked_by action returns a list of all brands that liked the current one.
Excludes matches and likes of a current brand.

Permissions to use this action:
 - user is authenticated
 - user has brand

### Added
 - liked_by api method
 - LikedBySerializer that returns only 3 fields:
   - id
   - name
   - logo
 - tests for liked_by action

### Updated
 - schema for swagger