### PR TITLE
Added my_likes and my_matches actions

### DIFF
--- a/core/apps/brand/schema.py
+++ b/core/apps/brand/schema.py
@@ -104,6 +104,15 @@ class Fix1(OpenApiViewExtension):
             def liked_by(self, request, *args, **kwargs):
                 return super().liked_by(request, *args, **kwargs)
 
+            @extend_schema(
+                tags=['Brand'],
+                description="Get a list of liked brands.\n\n"
+                            "instant_room: id of a room of type 'I' if it already exists OR null if it doesn't.\n\n"
+                            "Authenticated brand only."
+            )
+            def my_likes(self, request, *args, **kwargs):
+                return super().my_likes(request, *args, **kwargs)
+
         return Fixed
 
 

--- a/core/apps/brand/schema.py
+++ b/core/apps/brand/schema.py
@@ -4,7 +4,7 @@ from drf_spectacular.utils import extend_schema
 from core.apps.brand.serializers import (
     MatchSerializer,
     InstantCoopRequestSerializer,
-    InstantCoopSerializer, CollaborationSerializer, LikedBySerializer
+    InstantCoopSerializer, LikedBySerializer
 )
 
 
@@ -113,6 +113,15 @@ class Fix1(OpenApiViewExtension):
             def my_likes(self, request, *args, **kwargs):
                 return super().my_likes(request, *args, **kwargs)
 
+            @extend_schema(
+                tags=['Brand'],
+                description="Get a list of matches of the current brand.\n\n"
+                            "match_room: id of a room of type 'M'\n\n"
+                            "Authenticated brand only."
+            )
+            def my_matches(self, request, *args, **kwargs):
+                return super().my_matches(request, *args, **kwargs)
+
         return Fixed
 
 
@@ -146,6 +155,7 @@ class Fix3(OpenApiViewExtension):
             pass
 
         return Fixed
+
 
 def brand_me_postprocessing_hook(result, generator, request, public):
     description = {

--- a/tests/brand/test_my_likes.py
+++ b/tests/brand/test_my_likes.py
@@ -1,0 +1,165 @@
+from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from core.apps.brand.models import Category, Brand
+from core.apps.payments.models import Subscription
+
+User = get_user_model()
+
+
+class BrandMyLikesTestCase(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user1 = User.objects.create_user(
+            email='user1@example.com',
+            phone='+79993332211',
+            fullname='Юзеров Юзер Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.user2 = User.objects.create_user(
+            email='user2@example.com',
+            phone='+79993332212',
+            fullname='Юзеров Юзер1 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.user3 = User.objects.create_user(
+            email='user3@example.com',
+            phone='+79993332213',
+            fullname='Юзеров Юзер2 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        cls.auth_client1 = APIClient()
+        cls.auth_client2 = APIClient()
+        cls.auth_client3 = APIClient()
+
+        cls.auth_client1.force_authenticate(cls.user1)
+        cls.auth_client2.force_authenticate(cls.user2)
+        cls.auth_client3.force_authenticate(cls.user3)
+
+        brand_data = {
+            'tg_nickname': '@asfhbnaf',
+            'name': 'brand1',
+            'position': 'position',
+            'category': Category.objects.get(pk=1),
+            'inst_url': 'https://example.com',
+            'vk_url': 'https://example.com',
+            'tg_url': 'https://example.com',
+            'wb_url': 'https://example.com',
+            'lamoda_url': 'https://example.com',
+            'site_url': 'https://example.com',
+            'subs_count': 10000,
+            'avg_bill': 10000,
+            'uniqueness': 'uniqueness',
+            'logo': 'string',
+            'photo': 'string'
+        }
+
+        # TODO change business sub definition
+        cls.business_sub = Subscription.objects.create(name='Бизнес', cost=1000, duration=timedelta(days=180))
+
+        cls.brand1 = Brand.objects.create(user=cls.user1, subscription=cls.business_sub, **brand_data)
+        cls.brand2 = Brand.objects.create(user=cls.user2, **brand_data)
+        cls.brand3 = Brand.objects.create(user=cls.user3, subscription=cls.business_sub, **brand_data)
+
+        cls.url = reverse('brand-my_likes')
+        cls.like_url = reverse('brand-like')
+        cls.instant_coop_url = reverse('brand-instant-coop')
+
+    def test_my_likes_unauthenticated_not_allowed(self):
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_my_likes_wo_brand_not_allowed(self):
+        user_wo_brand = User.objects.create_user(
+            email='user4@example.com',
+            phone='+79993332214',
+            fullname='Юзеров Юзер3 Юзерович',
+            password='Pass!234',
+            is_active=True
+        )
+
+        auth_client_wo_brand = APIClient()
+        auth_client_wo_brand.force_authenticate(user_wo_brand)
+
+        response = auth_client_wo_brand.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_my_likes_no_likes(self):
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that returned list is empty
+        self.assertFalse(response.data)
+
+    def test_my_likes_no_instant_coops(self):
+        self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
+        response = self.auth_client1.get(self.url)  # get brands that were liked by brand1
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that there is only one brand that was liked by brand1
+        self.assertEqual(len(response.data), 1)
+
+        # check that there is no instant room for these brands
+        self.assertIsNone(response.data[0]['instant_room'])
+
+    def test_my_likes_with_instant_coop(self):
+        self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
+
+        # brand1 instant coops brand2, INSTANT room is created
+        instant_coop_resp = self.auth_client1.post(self.instant_coop_url, {'target': self.brand2.id})
+
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that instant room is not None
+        self.assertIsNotNone(response.data[0]['instant_room'])
+
+        self.assertEqual(response.data[0]['instant_room'], instant_coop_resp.data['id'])
+
+    def test_my_likes_includes_only_likes_of_current_brand(self):
+        self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
+        self.auth_client3.post(self.like_url, {'target': self.brand1.id})  # brand3 likes brand1
+
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that there is only 1 liked brand
+        self.assertEqual(len(response.data), 1)
+
+    def test_my_likes_exclude_matches(self):
+        self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
+        self.auth_client2.post(self.like_url, {'target': self.brand1.id})  # brand2 likes brand1 MATCH
+
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # check that response is empty
+        self.assertFalse(response.data)
+
+    def test_my_likes_can_return_more_than_one_brand(self):
+        self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
+        self.auth_client1.post(self.like_url, {'target': self.brand3.id})  # brand1 likes brand3
+        self.auth_client1.post(self.instant_coop_url, {'target': self.brand2.id})  # brand 1 instant coops brand2
+
+        response = self.auth_client1.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(len(response.data), 2)

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -1,0 +1,18 @@
+import json
+import unittest
+from contextlib import contextmanager
+
+from django.db import connections
+from django.test.utils import CaptureQueriesContext
+
+
+class AssertNumQueriesLessThanMixin(unittest.TestCase):
+    @contextmanager
+    def assertNumQueriesLessThan(self, value, using='default', verbose=False):
+        with CaptureQueriesContext(connections[using]) as context:
+            yield  # your test will be run here
+        if verbose:
+            msg = "\r\n%s" % json.dumps(context.captured_queries, indent=4)
+        else:
+            msg = None
+        self.assertLess(len(context.captured_queries), value, msg=msg)


### PR DESCRIPTION
### Added
 - `my_likes` action to get a list of brands that were liked by the current one
 - `my_matches` action to get a list of brands that have match with the current one
 - tests for these actions
 - serializers for these actions

### Updated
 - BrandViewSet
 - swagger schema

> [!NOTE]
> `my_likes` and `my_matches` only make 4 queries to the database, regardless of how many brands will be returned as a result.