### PR TITLE
Pagination for all list actions of brand viewset

### DIFF
--- a/core/apps/brand/pagination.py
+++ b/core/apps/brand/pagination.py
@@ -1,0 +1,17 @@
+from django.core.paginator import Paginator
+from django.utils.functional import cached_property
+from rest_framework.pagination import PageNumberPagination
+
+
+class FasterDjangoPaginator(Paginator):
+    # doesn't execute counting query
+    @cached_property
+    def count(self):
+        return len(self.object_list)
+
+
+class StandardResultsSetPagination(PageNumberPagination):
+    django_paginator_class = FasterDjangoPaginator
+    page_size = 100
+    page_size_query_param = 'page_size'
+    max_page_size = 1000

--- a/core/apps/brand/schema.py
+++ b/core/apps/brand/schema.py
@@ -8,9 +8,11 @@ from core.apps.brand.serializers import (
     InstantCoopSerializer,
     LikedBySerializer,
     BrandCreateResponseSerializer,
-    RecommendedBrandsSerializer
+    RecommendedBrandsSerializer,
+    MyLikesSerializer,
+    MyMatchesSerializer
 )
-from core.apps.brand.utils import get_paginated_response_serializer
+from core.apps.brand.utils import get_schema_standard_pagination_parameters
 
 
 class Fix1(OpenApiViewExtension):
@@ -65,7 +67,8 @@ class Fix1(OpenApiViewExtension):
                 description="Get a list of brands that liked the current one.\n\n"
                             "Excludes matches and likes of current brand.\n\n"
                             "Authenticated brand only.",
-                responses={200: LikedBySerializer(many=True)}
+                responses={200: LikedBySerializer(many=True)},
+                parameters=[] + get_schema_standard_pagination_parameters()
             )
             def liked_by(self, request, *args, **kwargs):
                 return super().liked_by(request, *args, **kwargs)
@@ -74,7 +77,9 @@ class Fix1(OpenApiViewExtension):
                 tags=['Brand'],
                 description="Get a list of liked brands.\n\n"
                             "instant_room: id of a room of type 'I' if it already exists OR null if it doesn't.\n\n"
-                            "Authenticated brand only."
+                            "Authenticated brand only.",
+                responses={200: MyLikesSerializer(many=True)},
+                parameters=[] + get_schema_standard_pagination_parameters()
             )
             def my_likes(self, request, *args, **kwargs):
                 return super().my_likes(request, *args, **kwargs)
@@ -83,7 +88,9 @@ class Fix1(OpenApiViewExtension):
                 tags=['Brand'],
                 description="Get a list of matches of the current brand.\n\n"
                             "match_room: id of a room of type 'M'\n\n"
-                            "Authenticated brand only."
+                            "Authenticated brand only.",
+                responses={200: MyMatchesSerializer(many=True)},
+                parameters=[] + get_schema_standard_pagination_parameters()
             )
             def my_matches(self, request, *args, **kwargs):
                 return super().my_matches(request, *args, **kwargs)
@@ -126,26 +133,8 @@ class Fix1(OpenApiViewExtension):
                                     'Up to 10 cities.\n\n'
                                     'If brand has at least one of the specified cities it will be included.'
                     ),
-                    OpenApiParameter(
-                        'page',
-                        OpenApiTypes.INT,
-                        OpenApiParameter.QUERY,
-                        description='Page number.\n\n'
-                                    'To get next or previous page use "next" and "previous" links from the response.'
-                                    '\n\n'
-                                    'To get last page pass "last" as a value.'
-                    ),
-                    OpenApiParameter(
-                        'page_size',
-                        OpenApiTypes.INT,
-                        OpenApiParameter.QUERY,
-                        description='Number of objects per page.\n\n'
-                                    '\tdefault: 100\n\n'
-                                    '\tmin: 1\n\n'
-                                    '\tmax: 1000'
-                    )
-                ],
-                responses={200: get_paginated_response_serializer(RecommendedBrandsSerializer)}
+                ] + get_schema_standard_pagination_parameters(),
+                responses={200: RecommendedBrandsSerializer(many=True)}
             )
             def recommended_brands(self, request, *args, **kwargs):
                 return super().recommended_brands(request, *args, **kwargs)

--- a/core/apps/brand/utils.py
+++ b/core/apps/brand/utils.py
@@ -1,4 +1,7 @@
-from rest_framework import serializers
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter
+
+from core.apps.brand.pagination import StandardResultsSetPagination
 
 
 def get_file_extension(filename):
@@ -8,20 +11,29 @@ def get_file_extension(filename):
     return '.' + filename.split('.')[-1]
 
 
-def get_paginated_response_serializer(
-        serializer: type[serializers.Serializer] | type[serializers.ModelSerializer]
-) -> type[serializers.Serializer]:
+def get_schema_standard_pagination_parameters() -> list[OpenApiParameter]:
     """
-    Decorator that should be used with serializers as response serializer in drf-spectacular schema.
-
-    Returns:
-        Serializer class that has pagination attributes.
+    Get standard pagination query parameters for use in OpenAPI schema generation.
     """
+    standard_pagination_class = StandardResultsSetPagination
 
-    class PaginatedSerializer(serializers.Serializer):
-        count = serializers.IntegerField(required=True)
-        next = serializers.URLField()
-        previous = serializers.URLField()
-        results = serializer(many=True, required=True)
-
-    return PaginatedSerializer
+    return [
+        OpenApiParameter(
+            'page',
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description='Page number.\n\n'
+                        'To get next or previous page use "next" and "previous" links from the response.'
+                        '\n\n'
+                        f'To get last page pass "{standard_pagination_class.last_page_strings[0]}" as a value.'
+        ),
+        OpenApiParameter(
+            standard_pagination_class.page_size_query_param,
+            OpenApiTypes.INT,
+            OpenApiParameter.QUERY,
+            description='Number of objects per page.\n\n'
+                        f'\tdefault: {standard_pagination_class.page_size}\n\n'
+                        '\tmin: 1\n\n'
+                        f'\tmax: {standard_pagination_class.max_page_size}'
+        )
+    ]

--- a/tests/brand/test_liked_by.py
+++ b/tests/brand/test_liked_by.py
@@ -92,7 +92,7 @@ class LikedByTestCase(APITestCase):
         response = self.auth_client1.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data)
+        self.assertFalse(response.data['results'])
 
     def test_liked_by_returns_correct_list_of_brands(self):
         self.auth_client2.post(self.like_url, {'target': self.brand1.id})  # brand2 likes brand1
@@ -103,8 +103,8 @@ class LikedByTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 1)
-        self.assertEqual(response.data[0]['id'], self.brand2.id)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['id'], self.brand2.id)
 
     def test_liked_by_excludes_matches(self):
         self.auth_client2.post(self.like_url, {'target': self.brand1.id})  # brand2 likes brand1
@@ -115,4 +115,4 @@ class LikedByTestCase(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)

--- a/tests/brand/test_my_likes.py
+++ b/tests/brand/test_my_likes.py
@@ -97,6 +97,7 @@ class BrandMyLikesTestCase(
         cls.like_url = reverse('brand-like')
         cls.instant_coop_url = reverse('brand-instant-coop')
 
+    # TODO optimize this method
     def create_n_likes(self, n: int) -> APIClient:
         users = User.objects.bulk_create([User(
             email=f'trash_user{i}@example.com',
@@ -163,7 +164,7 @@ class BrandMyLikesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that returned list is empty
-        self.assertFalse(response.data)
+        self.assertFalse(response.data['results'])
 
     def test_my_likes_no_instant_coops(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -172,10 +173,10 @@ class BrandMyLikesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that there is only one brand that was liked by brand1
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
         # check that there is no instant room for these brands
-        self.assertIsNone(response.data[0]['instant_room'])
+        self.assertIsNone(response.data['results'][0]['instant_room'])
 
     def test_my_likes_with_instant_coop(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -188,9 +189,9 @@ class BrandMyLikesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that instant room is not None
-        self.assertIsNotNone(response.data[0]['instant_room'])
+        self.assertIsNotNone(response.data['results'][0]['instant_room'])
 
-        self.assertEqual(response.data[0]['instant_room'], instant_coop_resp.data['id'])
+        self.assertEqual(response.data['results'][0]['instant_room'], instant_coop_resp.data['id'])
 
     def test_my_likes_includes_only_likes_of_current_brand(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -201,7 +202,7 @@ class BrandMyLikesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that there is only 1 liked brand
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_my_likes_exclude_matches(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -212,7 +213,7 @@ class BrandMyLikesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that response is empty
-        self.assertFalse(response.data)
+        self.assertFalse(response.data['results'])
 
     def test_my_likes_can_return_more_than_one_brand(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -223,7 +224,7 @@ class BrandMyLikesTestCase(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data['results']), 2)
 
     @tag('slow')
     def test_number_of_queries_less_than_7(self):

--- a/tests/brand/test_my_matches.py
+++ b/tests/brand/test_my_matches.py
@@ -73,6 +73,7 @@ class BrandMyMatchesTestCase(
         cls.url = reverse('brand-my_matches')
         cls.like_url = reverse('brand-like')
 
+    # TODO optimize this method
     def create_n_matches(self, n: int) -> APIClient:
         """
         Create n matches in db.
@@ -157,7 +158,7 @@ class BrandMyMatchesTestCase(
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # check that returned list is empty
-        self.assertFalse(response.data)
+        self.assertFalse(response.data['results'])
 
     def test_my_matches(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -169,16 +170,16 @@ class BrandMyMatchesTestCase(
         self.assertEqual(client1_response.status_code, status.HTTP_200_OK)
         self.assertEqual(client2_response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(client1_response.data), 1)
-        self.assertEqual(len(client2_response.data), 1)
+        self.assertEqual(len(client1_response.data['results']), 1)
+        self.assertEqual(len(client2_response.data['results']), 1)
 
         # check that both brands will receive each other
-        self.assertEqual(client1_response.data[0]['id'], self.brand2.id)
-        self.assertEqual(client2_response.data[0]['id'], self.brand1.id)
+        self.assertEqual(client1_response.data['results'][0]['id'], self.brand2.id)
+        self.assertEqual(client2_response.data['results'][0]['id'], self.brand1.id)
 
         # check that both brands will receive same room
-        self.assertEqual(client1_response.data[0]['match_room'], match_response.data['room'])
-        self.assertEqual(client2_response.data[0]['match_room'], match_response.data['room'])
+        self.assertEqual(client1_response.data['results'][0]['match_room'], match_response.data['room'])
+        self.assertEqual(client2_response.data['results'][0]['match_room'], match_response.data['room'])
 
     def test_my_matches_can_return_more_than_one_brand(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -190,7 +191,7 @@ class BrandMyMatchesTestCase(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 2)
+        self.assertEqual(len(response.data['results']), 2)
 
     def test_my_matches_returns_matches_of_current_brand(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -203,7 +204,7 @@ class BrandMyMatchesTestCase(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_my_matches_excludes_likes(self):
         self.auth_client1.post(self.like_url, {'target': self.brand2.id})  # brand1 likes brand2
@@ -214,7 +215,7 @@ class BrandMyMatchesTestCase(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data['results']), 1)
 
     @tag('slow')
     def test_number_of_queries_less_than_7(self):


### PR DESCRIPTION
### Added

- pagination for the following actions of brand viewset:
  - `liked_by`
  - `my_likes`
  - `my_matches`

### Updated

- tests for these actions
- OpenAPI schema
