### PR TITLE
Fix brand instant coop

### DIFF
--- a/core/apps/brand/api.py
+++ b/core/apps/brand/api.py
@@ -653,8 +653,12 @@ class BrandViewSet(
         Instant cooperation.
         Returns room instance.
 
-        Only one cooperation room per a pair of brands. No matter who were the initiator.
         If room already exists, will raise BadRequest exception (400) and return error text with existing room id.
+
+        After calling this method you should use room id to connect to the room and send a message.
+        Only 1 message can be created by the user.
+
+        Requires target to be liked by the user. Otherwise, permission will be denied (403).
 
         Business subscription only.
         """

--- a/core/apps/brand/api.py
+++ b/core/apps/brand/api.py
@@ -15,7 +15,7 @@ from core.apps.analytics.models import BrandActivity
 from core.apps.analytics.utils import log_brand_activity
 from core.apps.brand.models import Brand, Category, Format, Goal, ProductPhoto, GalleryPhoto, Tag, BusinessGroup, Blog
 from core.apps.brand.pagination import StandardResultsSetPagination
-from core.apps.brand.permissions import IsBusinessSub, IsBrand
+from core.apps.brand.permissions import IsBusinessSub, IsBrand, CanInstantCoop
 from core.apps.brand.serializers import (
     QuestionnaireChoicesSerializer,
     BrandCreateSerializer,
@@ -27,7 +27,8 @@ from core.apps.brand.serializers import (
     LikedBySerializer,
     MyLikesSerializer,
     MyMatchesSerializer,
-    RecommendedBrandsSerializer, BrandMeSerializer,
+    RecommendedBrandsSerializer,
+    BrandMeSerializer,
 )
 from core.apps.chat.models import Room
 from core.apps.payments.models import Subscription
@@ -496,7 +497,7 @@ class BrandViewSet(
         elif self.action in ('like', 'liked_by', 'my_likes', 'my_matches', 'recommended_brands'):
             permission_classes = [IsAuthenticated, IsBrand]
         elif self.action == 'instant_coop':
-            permission_classes = [IsAuthenticated, IsBrand, IsBusinessSub]
+            permission_classes = [IsAuthenticated, IsBrand, IsBusinessSub, CanInstantCoop]
         else:
             permission_classes = [IsAuthenticated]
         return [permission() for permission in permission_classes]

--- a/core/apps/brand/permissions.py
+++ b/core/apps/brand/permissions.py
@@ -1,5 +1,8 @@
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework import permissions
+
+from core.apps.brand.models import Match
 
 
 class IsOwnerOrReadOnly(permissions.BasePermission):
@@ -35,3 +38,24 @@ class IsBusinessSub(permissions.BasePermission):
         return request.user.brand.subscriptions.filter(
             is_active=True, end_date__gt=timezone.now(), tariff__name='Business Match'
         ).exists()
+
+
+class CanInstantCoop(permissions.BasePermission):
+    """
+    Allow access to brands that liked the target and don't have match with it
+    """
+    def has_permission(self, request, view):
+        current_brand_id = request.user.brand.id
+        target_id = request.data['target']
+
+        # no need to check for match because
+        # access allowed only if the current brand liked the target but don't have match with it yet.
+        # It means that access allowed only if the current brand
+        # is the initiator and haven't received like in response yet
+        has_liked_target = Match.objects.filter(
+            initiator_id=current_brand_id,
+            target_id=target_id,
+            is_match=False
+        ).exists()
+
+        return has_liked_target

--- a/core/apps/brand/schema.py
+++ b/core/apps/brand/schema.py
@@ -46,8 +46,18 @@ class Fix1(OpenApiViewExtension):
                 return super().retrieve(request, *args, **kwargs)
 
             @extend_schema(
-                description='Лайкнуть бренд\n\n'
-                            'target: id бренда',
+                description='Like a brand\n\n'
+                            '\ttarget: brand id\n\n'
+                            'Situations and outcomes:\n\n'
+                            '\t1) brand1 "like" brand2 -> like (is_match: false, room: null)\n\n'
+                            '\t2) brand1 "like" brand2 & brand2 "like" brand1 '
+                            '-> match (is_match: true, room: 1 (room type is MATCH))\n\n'
+                            '\t3) brand1 "like" brand2 & brand1 "instant coop" brand2 '
+                            '-> like + 1 message (is_match: false, room: 1 (room type is INSTANT))\n\n'
+                            '\t4) brand1 "like" brand2 & brand1 "instant coop" brand2 & brand2 "like" brand1 '
+                            '-> like + 1 message (is_match: false, room: 1 (room type is INSTANT)) '
+                            '-> match (is_match: true, room: 1 (room type is MATCH, id did not change))\n\n'
+                            'Authenticated brand only',
                 tags=['Brand'],
                 responses={201: MatchSerializer}
             )


### PR DESCRIPTION
The instant coop now used to send only 1 message along with a like.
If target likes brand in response then match will happen (room type will be changed to MATCH, id remains the same)

### Updated

- instant coop now allows to send only 1 message
- tests
- schema