### PR TITLE
Files cleanup

### DIFF
--- a/core/config/settings.py
+++ b/core/config/settings.py
@@ -37,6 +37,9 @@ INSTALLED_APPS = [
     'core.apps.analytics.apps.AnalyticsConfig',
     'core.apps.cities.apps.CitiesConfig',
     'core.apps.blacklist.apps.BlacklistConfig',
+
+    # should be last
+    'django_cleanup.apps.CleanupConfig',
 ]
 
 MIDDLEWARE = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -538,6 +538,17 @@ pytz = "*"
 unidecode = ">=0.04.13"
 
 [[package]]
+name = "django-cleanup"
+version = "9.0.0"
+description = "Deletes old files."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_cleanup-9.0.0-py3-none-any.whl", hash = "sha256:19f8b0e830233f9f0f683b17181f414672a0f48afe3ea3cc80ba47ae40ad880c"},
+    {file = "django_cleanup-9.0.0.tar.gz", hash = "sha256:bb9fb560aaf62959c81e31fa40885c36bbd5854d5aa21b90df2c7e4ba633531e"},
+]
+
+[[package]]
 name = "djangochannelsrestframework"
 version = "1.3.0"
 description = "RESTful API for WebSockets using django channels."
@@ -1918,4 +1929,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "61d6c7453518cff3e91b2153c3063621009191f5d57233eda1d408ca85b5aec1"
+content-hash = "3dfd6abf1629646ec2135cfc98d69d63c8a3af1bb3b4347c8b19d70e9435de28"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dj-database-url = "^2.3.0"
 whitenoise = {extras = ["brotli"], version = "^6.8.2"}
 django-cities-light = "^3.10.1"
 python-dateutil = "^2.9.0.post0"
+django-cleanup = "^9.0.0"
 
 
 [tool.poetry.group.prod.dependencies]


### PR DESCRIPTION
### Added

- django-cleanup package to clean up old media files

### Updated

- update and delete brand tests now use `APITransactionTestCase` instead of `APITestCase` because django-cleanup requires it
- `BrandUpdateSerializer` now doesn't handle file deletions, django-cleanup takes it on